### PR TITLE
chore: platform version bump

### DIFF
--- a/io.github.erkin.ponysay.appdata.xml
+++ b/io.github.erkin.ponysay.appdata.xml
@@ -18,6 +18,54 @@
   </description>
   <developer_name>Erkin Batu Altunbaş, Mattias Andrée, Elis Axelsson et al.</developer_name>
   <releases>
+      <release date="2022-02-20" version="3.0.3a">
+      <pre>
+New ponies: auntorange, caballeron, cocopommel, coloratura, coriander, 
+	    doublediamond, ember, flurryheart, fluttershybat, 
+	    fluttershybathang, freshcoat, goldiedelicious, grace, greta, 
+	    kevin, kingthorax, lovemelody, moondancer, pharynx, plaidstripes, 
+	    princepharynx, rara, saffron, starlightglimmer, stellareclipse, 
+	    stormyflare, sunburst, sunburstcape, svengallop, thesmooze, 
+	    thorax, tirek, treehugger, troubleshoes, twilightbreezie, 
+	    whoanelly, zephyrbreeze, zipporwhill, zipporwhillsfather
+	    
+New extraponies: cocoachill, riverbeauty, velvetremedy
+
+Pony symlink added: cookiecrumbles → raritysmom (official name)
+		    bettyboufant → raritysmom (Gameloft name)
+		    hondoflanks → raritysdad (official name)
+		    royalpin → pockeypierce (Gamelft name)
+		    cloudyquartz → sue (Gameloft name)
+		    cocopommel → misscoco (changed in serie)
+		    horsemd → doctop (official mame)
+		    fleurdelis → fleurdislee (Gameloft name)
+		    blinkie → limestone (Official name)
+		    inky → marble (Official name)
+		    clyde → igneousrock (Official name)
+		    hughjelly → hughbertjellius (Official name)
+		    drcaballeron → caballeron (Official spelling)
+		    countess → rara (Real name)
+		    stormyflare → spitfiresmom (family relationship)
+		    airheart → jetstream (official name on merchandise)
+		    raindrops → sunshowerraindros (official name on merchandise)
+		    lovemelody → venus (resemblance)
+		    grace → manewitz (part of the official name on merchandice)
+
+Special pony cases:
+* orange was renamed to uncleorange to not conflict with auntorange.
+* cocopommel was renamed to misspommel in the serie and merchandise
+  a symlink was provided pointing to the old name
+* maudepie was renamed to maudpie since that her real name, we 
+  just misswrite it
+
+Changed all the references from griffin to griffon, that the apropiate
+canon in-universe name for this creature.
+
+Code is cleaned and improved.
+
+Initial fullwidth CJK characters support added.
+      </pre>
+    </release>
     <release date="2017-10-6" version="3.0.3">
       <pre>
 New ponies: auntorange, caballeron, cocopommel, coloratura, coriander, 

--- a/io.github.erkin.ponysay.yaml
+++ b/io.github.erkin.ponysay.yaml
@@ -1,13 +1,15 @@
 app-id: io.github.erkin.ponysay
 runtime: org.freedesktop.Platform
-runtime-version: '19.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
-command: /app/bin/ponysay
+command: /app/bin/ponysay.sh
 modules:
   - name: ponysay
     buildsystem: simple
     build-commands:
       - ./setup.py --prefix /app --freedom=partial install
+      - echo -e '#!/bin/sh\nPYTHONWARNINGS=ignore /app/bin/ponysay "$@"' > /app/bin/ponysay.sh
+      - chmod +x /app/bin/ponysay.sh
     sources:
       - type: git
         url: https://github.com/erkin/ponysay.git


### PR DESCRIPTION
New version of python complains about some deprecated syntax in upstream; this update also wraps ponysay in shell script disabling those warnings until upstream releases a new version.